### PR TITLE
Add sitemap.xml

### DIFF
--- a/404.md
+++ b/404.md
@@ -2,6 +2,7 @@
 layout: baselayout.njk 
 title: Sidan saknas | CoderDojo Stockholm 
 upcomingDojosToShow: 2 
+eleventyExcludeFromCollections: true
 eleventyImport: 
     collections: ["dojo"] 
 ---
@@ -14,7 +15,7 @@ Dessa är våra framtida planerade Dojos:
 <ul>
 {%- for dojo in collections.upcomingDojos -%}
     <li>
-        <a href="{{ dojo.url }}">Dojo {{ dojo.date | betterDate }}</a>
+        <a href="{{ dojo.url }}">Dojo {{ dojo.fileSlug }}</a>
     </li>
 {%- endfor -%}
 </ul>

--- a/_includes/baselayout.njk
+++ b/_includes/baselayout.njk
@@ -1,5 +1,6 @@
 ---
 title: CoderDojo Stockholm
+date: "git Last Modified"
 ---
 
 <!DOCTYPE html>

--- a/_includes/dojolayout.njk
+++ b/_includes/dojolayout.njk
@@ -2,6 +2,7 @@
 layout: baselayout.njk
 permalink: "dojo/{{ page.fileSlug }}/index.html"
 date: "git Last Modified"
+changefreq: "never"
 ---
 
 <a href="/">⬅️ Till startsidan</a>

--- a/_includes/dojolayout.njk
+++ b/_includes/dojolayout.njk
@@ -1,12 +1,12 @@
 ---
 layout: baselayout.njk
-permalink: "dojo/{{ page.date | betterDate }}/index.html"
-title: "Dojo {{page.date | betterDate }} | CoderDojo Stockholm"
+permalink: "dojo/{{ page.fileSlug }}/index.html"
+date: "git Last Modified"
 ---
 
 <a href="/">⬅️ Till startsidan</a>
 
-<h1>CoderDojo Stockholm {{ page.date | betterDate }}<h2>
+<h1>CoderDojo Stockholm {{ page.fileSlug }}<h2>
 
 {{content | safe}}
 

--- a/_includes/sublayout.njk
+++ b/_includes/sublayout.njk
@@ -1,7 +1,8 @@
 ---
 layout: baselayout.njk
-permalink: "dojo/{{ page.date | betterDate }}/index.html"
 title: "CoderDojo Stockholm"
+date: "git Last Modified"
+changefreq: "monthly"
 ---
 
 <a href="/">⬅️ Till startsidan</a>

--- a/dojos/dojos.11tydata.json
+++ b/dojos/dojos.11tydata.json
@@ -4,6 +4,6 @@
         "dojo"
     ],
     "eleventyComputed": {
-        "title": "Dojo {{ page.date | betterDate }} | CoderDojo Stockholm"
+        "title": "Dojo {{ page.fileSlug }} | CoderDojo Stockholm"
     }
 }

--- a/dojos/next-dojo.md
+++ b/dojos/next-dojo.md
@@ -1,6 +1,7 @@
 ---
 layout: sublayout.njk
 permalink: "next-dojo/index.html"
+changefreq: "weekly"
 eleventyComputed:
   title: "CoderDojo Stockholm | Vår nästa Dojo"
 ---
@@ -13,6 +14,8 @@ CoderDojo Stockholm är en förening som erbjuder gratis event för barn mellan 
 Alla våra event är gratis och riktar sig till alla. Oavsett om du tidigare provat på programmering eller inte.
 
 Den här sidan visar alltid informationen kring den närmaste Dojon. Observera att vi är på olika platser i närheten eller i Stockholm.
+
+{{ dojo.content }}
 
 <div class="tt-widget">
 <div class="tt-widget-fallback">

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -5,13 +5,13 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.addCollection("upcomingDojos", function(collectionApi) {
         return collectionApi.getFilteredByTag("dojo").filter(function(item) {
-            return item.date > Date.now();
+            return new Date(item.fileSlug) > Date.now();
         });
     });
 
     eleventyConfig.addCollection("previousDojos", function(collectionApi) {
         return collectionApi.getFilteredByTag("dojo").filter(function(item) {
-            return item.date < Date.now();
+            return new Date(item.fileSlug) < Date.now();
         });
     });
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 --- 
 layout: baselayout.njk 
 title: CoderDojo Stockholm
+changefreq: "weekly"
 eleventyImport: 
     collections: ["dojo"] 
 ---
@@ -14,7 +15,7 @@ Här under kan du både se våra kommande Dojos men även lära dig mer om Coder
 <ul>
 {%- for dojo in collections.upcomingDojos -%}
     <li>
-        <a href="{{ dojo.url }}">Dojo {{ dojo.date | betterDate }}</a>
+        <a href="{{ dojo.url }}">Dojo {{ dojo.fileSlug }}</a>
     </li>
 {%- endfor -%}
 </ul>

--- a/misc/email-saved.md
+++ b/misc/email-saved.md
@@ -2,6 +2,7 @@
 layout: baselayout.njk
 title: "Vi sparar din mejl"
 noindex: true
+eleventyExcludeFromCollections: true
 ---
 
 # Vi sparar din mejl

--- a/misc/sitemap.liquid
+++ b/misc/sitemap.liquid
@@ -1,0 +1,18 @@
+--- 
+permalink: '/sitemap.xml' 
+eleventyExcludeFromCollections: true 
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in collections.all %}
+    <url>
+      {% if page.url == "/" %}
+        <loc>/</loc>
+      {% else %}
+        <loc>{{ page.url | url | remove_last: "/" }}</loc>
+      {% endif %}
+      <lastmod>{{ page.date | betterDate }}</lastmod>
+      <changefreq>{{ page.data.changefreq | default: "yearly" }}</changefreq>
+    </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
Adds a fairly simple but well covering sitemap to the site.
Each page can get unique changefreq by sitting the frontmatter data `changefreq`, it also uses the `git Last Modified` as the `lastmod` value and stops using the date in ways it shouldn't be used 😅

closes #8 