### PR TITLE
Sort dojos by filename, not by update date

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,15 +4,14 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.ignores.add("README.md");
 
     eleventyConfig.addCollection("upcomingDojos", function(collectionApi) {
-        return collectionApi.getFilteredByTag("dojo").filter(function(item) {
+        let filteredCollection = collectionApi.getFilteredByTag("dojo").filter(function(item) {
             return new Date(item.fileSlug) > Date.now();
-        });
-    });
+        })
 
-    eleventyConfig.addCollection("previousDojos", function(collectionApi) {
-        return collectionApi.getFilteredByTag("dojo").filter(function(item) {
-            return new Date(item.fileSlug) < Date.now();
+        filteredCollection.sort((a,b) => {
+            return new Date(a.fileSlug) - new Date(b.fileSlug);
         });
+        return filteredCollection;
     });
 
     eleventyConfig.addFilter("betterDate", function(value) {


### PR DESCRIPTION
This update changes so that the list of upcoming dojos is sorted on the filename, and not by the git last updated date.